### PR TITLE
Update GATT connect function

### DIFF
--- a/bluetooth-toy-bb8/index.html
+++ b/bluetooth-toy-bb8/index.html
@@ -372,7 +372,7 @@ limitations under the License.
             .then(device => {
               console.log('> Found ' + device.name);
               console.log('Connecting to GATT Server...');
-              return device.connectGATT();
+              return device.gatt.connect();
             })
             .then(server => {
               gattServer = server;


### PR DESCRIPTION
Chrome 50+ uses `device.gatt.connect`, rather than `device.connectGATT`.

I know WebBluetoothCG has its own BB8 demo, but I like the audio version here :)